### PR TITLE
Honor no layout overrides

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ exports = module.exports = function (app, settings) {
 
     var html = yield *render(view, options);
 
-    var layout = options.layout || settings.layout;
+    var layout = ("layout" in options && options.layout === false) ? false : (options.layout || settings.layout);
     if (layout) {
       // if using layout
       options.body = html;


### PR DESCRIPTION
After implementing koa-error-ejs in an application, I discovered that setting the layout to false was not being honored - the default layout was being applied.

This fix allows us to render a view with `layout: false` in the render options.
