### PR TITLE
Add koa 2 workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,23 @@ app.listen(7001);
 
 Or you can checkout the [example](https://github.com/dead-horse/koa-ejs/tree/master/example).
 
+### Wokraround for Koa 2
+
+```sh
+npm install co --save
+```
+```javascript
+import co from 'co';
+import render from 'koa-ejs';
+
+render(app, options);
+app.context.render = co.wrap(app.context.render);
+
+app.use(async (ctx, next) => {
+    await ctx.render(view, locals);
+});
+```
+
 ### settings
 
 * root: view root directory.


### PR DESCRIPTION
I'm not sure whether this PR might close #23, but I think this workaround is useful until there is no active development of koa-ejs@next  😼