### PR TITLE
add locals to render context

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,6 +94,7 @@ exports = module.exports = function (app, settings) {
     var context = {};
     merge(context, this.state);
     merge(context, _context);
+    merge(context, settings.locals);
 
     var html = yield *render(view, context);
 


### PR DESCRIPTION
add locals to render context for default/static configuration
example:

```
render(app, {
    . . .
    locals: {
        _: require('lodash'),
        site: config.get('site'),
        env: app.env
    }
});
```
