### PR TITLE
Make `viewExt` option support `include` directive

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -21,7 +21,7 @@ render(app, {
   layout: 'template',
   viewExt: 'html',
   cache: false,
-  debug: true
+  debug: false,
 });
 
 app.use(function (ctx, next) {

--- a/example/view/content.noext.html
+++ b/example/view/content.noext.html
@@ -1,0 +1,4 @@
+<div>
+  <p>request ip is: <%= ip %></p>
+  <% include user %>
+</div>

--- a/example/view/template.oc.html
+++ b/example/view/template.oc.html
@@ -2,8 +2,8 @@
   <head>
     <title>koa ejs</title>
   </head>
-  <h3>koa ejs</h3>
   <body>
+    <h3>koa ejs</h3>
     <?- body ?>
   </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -79,6 +79,16 @@ exports = module.exports = function (app, settings) {
     }
 
     const tpl = await fs.readFile(viewPath, 'utf8');
+    
+    // override `ejs` node_module `resolveInclude` function
+    const parentResolveInclude = ejs.resolveInclude;
+    ejs.resolveInclude = function(name, filename, isDir) {
+      if (!path.extname(name)) {
+        name += settings.viewExt;
+      }
+      return parentResolveInclude(name, filename, isDir);
+    }
+    
     const fn = ejs.compile(tpl, {
       filename: viewPath,
       _with: settings._with,

--- a/test/koa-ejs.test.js
+++ b/test/koa-ejs.test.js
@@ -68,5 +68,33 @@ describe('test/koa-ejs.test.js', function () {
         .expect('content-type', 'text/html; charset=utf-8')
         .expect(/Zed Gu/, done);
     });
+    it('should render page ok with `viewExt` option supporting `include` directive', function (done) {
+      const app = new Koa();
+      render(app, {
+        root: 'example/view',
+        layout: 'template',
+        viewExt: 'html',
+        cache: false
+      });
+
+      app.use(function (ctx, next) {
+        ctx.state = ctx.state || {};
+        ctx.state.ip = ctx.ip;
+        return next();
+      });
+
+      app.use(async function (ctx) {
+        const users = [{ name: 'Dead Horse' }, { name: 'Runrioter Wung' }];
+        await ctx.render('content.noext', {
+          users
+        });
+      });
+      request(app.callback())
+        .get('/')
+        .expect(200)
+        .expect('content-type', 'text/html; charset=utf-8')
+        .expect(/Dead Horse/)
+        .expect(/Runrioter Wung/, done);
+    });
   });
 });


### PR DESCRIPTION
Currently, `viewExt` option just work well on `layout` view option and `ctx.render` view param. 
When `include` directive includes view file without file extension, it ignores `viewExt` option. 
It's not reasonable that it is `.ejs` but not `viewExt`.

Original|Received|Expected
-------|---------|----------
`<%- include item%>`|`<%- include item.ejs%>`|`<%- include item.{viewExt}%>`

So I create this pull request. 
But if somebody uses both `viewExt` option and the default `.ejs` messily, this maybe be a little breaking change.

So please review it. @dead-horse 