### PR TITLE
Add support for outputFunctionName settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Or you can checkout the [example](https://github.com/koajs/ejs/tree/master/examp
 * debug: debug flag (default `false`).
 * delimiter: character to use with angle brackets for open / close (default `%`).
 * async: When true, EJS will use an async function for rendering. Depends on async/await support in the JS runtime.
+* outputFunctionName: Set to a string (e.g., 'echo' or 'print') for a function to print output inside scriptlet tags.
 
 ### Layouts
 

--- a/index.js
+++ b/index.js
@@ -100,7 +100,8 @@ exports = module.exports = function (app, settings) {
       debug: settings.debug,
       delimiter: settings.delimiter,
       cache: settings.cache,
-      async: settings.async
+      async: settings.async,
+      outputFunctionName: settings.outputFunctionName
     });
     if (settings.cache) {
       cache[viewPath] = fn;


### PR DESCRIPTION
This option allows to set a string (e.g., 'echo' or 'print') for a function to print output inside scriptlet tags.