### PR TITLE
Move definition of resolveInclude() override out of closure

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,14 @@ exports = module.exports = function (app, settings) {
     ? '.' + settings.viewExt.replace(/^\./, '')
     : '';
 
+  // override `ejs` node_module `resolveInclude` function
+  ejs.resolveInclude = function(name, filename, isDir) {
+    if (!path.extname(name)) {
+      name += settings.viewExt;
+    }
+    return parentResolveInclude(name, filename, isDir);
+  }
+
   /**
    * generate html with view name and options
    * @param {String} view
@@ -84,14 +92,6 @@ exports = module.exports = function (app, settings) {
     }
 
     const tpl = await fs.readFile(viewPath, 'utf8');
-
-    // override `ejs` node_module `resolveInclude` function
-    ejs.resolveInclude = function(name, filename, isDir) {
-      if (!path.extname(name)) {
-        name += settings.viewExt;
-      }
-      return parentResolveInclude(name, filename, isDir);
-    }
 
     const fn = ejs.compile(tpl, {
       filename: viewPath,


### PR DESCRIPTION
Two problems:

* `ejs` already provides a mechanism to provide a custom `fileLoader()`, which does not appear to be honoured (never reached) because `koa-ejs` itself overrides `ejs's resolveInclude()` which interferes early in the process.

* `koa-ejs` override of `ejs.resolveInclude()` happens within a closure, so even if the application attempts to override the `koa-ejs` override, it cannot since `koa-ejs` version is always re-applied within the closure.

This fix simply moves the `ejs.resolveInclude()` override out of the closure as it does not depend on anything from within the closure, allowing an application the option to override include file path determination.

In my case I want to be able to set `views` as a base directory, then every `include` path is relative the `views` without need of relative `../` elements. eg.

```
render(app, settings);
render.ejs.resolveInclude = function ejsResolveInclude(target, parent, isdir) {
    return path.join(app_options.locations.views, target);
};
```
