### PR TITLE
add '(templateName: string) => Promise<string>' overload to settings.root

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Or you can checkout the [example](https://github.com/koajs/ejs/tree/master/examp
 
 ### settings
 
-* root: view root directory.
+* root: view root directory. Also supports callback of type `(templateName: string) => Promise</* template content */ string>`.
 * layout: global layout file, default is `layout`, set `false` to disable layout.
 * viewExt: view file extension (default `html`).
 * cache: cache compiled templates (default `true`).

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ exports = module.exports = function (app, settings) {
     throw new Error('settings.root required');
   }
 
-  settings.root = path.resolve(process.cwd(), settings.root);
+  settings.root = typeof settings.root === "string" ? path.resolve(process.cwd(), settings.root) : settings.root;
 
   /**
    * cache the generate package
@@ -84,14 +84,14 @@ exports = module.exports = function (app, settings) {
    */
   async function render(view, options) {
     view += settings.viewExt;
-    const viewPath = path.join(settings.root, view);
+    const viewPath = typeof settings.root === "string" ? path.join(settings.root, view) : view;
     debug(`render: ${viewPath}`);
     // get from cache
     if (settings.cache && cache[viewPath]) {
       return cache[viewPath].call(options.scope, options);
     }
 
-    const tpl = await fs.readFile(viewPath, 'utf8');
+    const tpl = typeof settings.root === "string" ? await fs.readFile(viewPath, 'utf8') : await settings.root(viewPath);
 
     const fn = ejs.compile(tpl, {
       filename: viewPath,


### PR DESCRIPTION
POC for https://github.com/koajs/ejs/issues/56

If you interested I can add tests and so on. I am myself not sure of api yet. Maybe I should leave root as is, and add one additional option `getTemplate` which if defined will receive fullpath of template, i.e `root + view + ext`