### PR TITLE
Update to support ejs 3.x (significant changes to include syntax)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ Also you can set `layout = false` to disable the layout.
 
 Supports ejs includes.
 
+If you are upgrading from ejs 2.x, note the change in ejs 3.x include syntax
+
 ```
 <div>
-  <% include user.html %>
+  <%- include('user.html') %>
 </div>
 ```
 

--- a/example/view/content.html
+++ b/example/view/content.html
@@ -1,4 +1,4 @@
 <div>
   <p>request ip is: <%= ip %></p>
-  <% include user.html %>
+  <%- include('user.html') %>
 </div>

--- a/example/view/content.noext.html
+++ b/example/view/content.noext.html
@@ -1,4 +1,4 @@
 <div>
   <p>request ip is: <%= ip %></p>
-  <% include user %>
+  <%- include('user') %>
 </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-ejs",
-  "version": "4.3.0",
+  "version": "5.0.0",
   "description": "ejs render middleware for koa",
   "main": "index.js",
   "scripts": {
@@ -27,13 +27,13 @@
   "homepage": "https://github.com/koajs/ejs",
   "devDependencies": {
     "koa": "^2.0.1",
-    "mocha": "^3.2.0",
+    "mocha": "^8.1.3",
     "should": "^11.2.0",
     "supertest": "^3.0.0"
   },
   "dependencies": {
     "debug": "^2.6.1",
-    "ejs": "^2.6.1",
+    "ejs": "^3.1.5",
     "mz": "^2.6.0"
   },
   "engine": {


### PR DESCRIPTION
This PR implements the minimum changes needed to support ejs 3.x.

Because the ejs include syntax has changed in ejs 3.x, I've increased the major version number here to signal a breaking change. EJS templates need to change from this:

```ejs
<% include foo %>
```

to this
```ejs
<%- include('foo') %>
```
